### PR TITLE
update appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,6 @@ environment:
       R_VERSION: oldrel
     - configuration: release
       R_VERSION: release
-    - configuration: devel
-      R_VERSION: devel
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
this is a bioconductor issue checks always fail becuase rhdf5 is not available for the development version